### PR TITLE
Add pytest tests and fixtures

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,17 @@ Edit the `PATTERNS` dict in `sds_parser.py`. For each new supplier:
 
 **Tip:** Keep a small test corpus; add a basic unit test per new pattern to avoid regressions.
 
+## 🧪 Running Tests
+
+The project includes a small pytest suite. After installing the required
+packages, simply run:
+
+```bash
+pytest
+```
+
+Fixtures with example SDS snippets live in `tests/fixtures`.
+
 ---
 
 ## ⚠️ Limitations & Next Steps

--- a/tests/fixtures/sample.pdf
+++ b/tests/fixtures/sample.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250720134648+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250720134648+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 322
+>>
+stream
+Garo;Yti1j'LhbF`>nt.-$GeJA:r<n!@gLM0Y3*>K'^!,0qs%YVXDg)QDHNBkIg[E60]OPc:.mH*4K\b6GY_p2J:so=RhgZ-RZ9o..S'Wj6G0`ehn+!6H^!W0f0-bPO#eqn5&PC$YG\Hbni+E:,J0@d["#6#ea;[C$\$$dZD#PYH]hR&dt"e,0Ak3)PZ*LG<be5."/-AAI2pFAT8MA.e,$*CYXa"D9'cmo(Cl$(`/*lodGQc[/]-L1$r*>9B4=W<(MknP?Al9@<jGoanGdpP?E3T7N<X]@7=mjWo&6'"$.a8(0`)YqCgI0B/4(K>bHm#~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<73fe8cbe3707607ebc501c41aa7dfa89><73fe8cbe3707607ebc501c41aa7dfa89>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1239
+%%EOF

--- a/tests/fixtures/sample_text.txt
+++ b/tests/fixtures/sample_text.txt
@@ -1,0 +1,10 @@
+Product Name: Fancy Stuff
+Manufacturer: ExampleCorp
+CAS No.: 64-17-5
+Revision: 12-04-24
+Hazardous Substance: Yes
+Dangerous Goods: No
+Class: 3
+Section 2
+Danger
+H225 Highly flammable liquid

--- a/tests/test_sds_parser.py
+++ b/tests/test_sds_parser.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import sys
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from sds_parser import extract_fields, parse_date, compute_risk_rating, extract_text_from_pdf
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+with open(FIXTURE_DIR / "sample_text.txt", "r", encoding="utf-8") as f:
+    SAMPLE_TEXT = f.read()
+
+
+def test_parse_date_formats():
+    assert parse_date("12/04/2023") == "12/04/2023"
+    assert parse_date("12-04-23") == "12/04/2023"
+    assert parse_date("04/12/2023") == "04/12/2023"
+    assert parse_date(None) is None
+    # Invalid date returns input
+    assert parse_date("31/04/2023") == "31/04/2023"
+
+
+def test_compute_risk_rating():
+    assert compute_risk_rating("insignificant", "rare") == "Low (1)"
+    assert compute_risk_rating("moderate", "likely") == "High (12)"
+    assert compute_risk_rating("severe", "almost certain") == "Extreme (25)"
+    assert compute_risk_rating("unknown", "rare") is None
+    assert compute_risk_rating(None, None) is None
+
+
+def test_extract_fields_from_text():
+    record = extract_fields(SAMPLE_TEXT)
+    assert record.product_name == "Fancy Stuff"
+    assert record.vendor == "ExampleCorp"
+    assert record.cas_number == "64-17-5"
+    assert record.issue_date == "12/04/2024"
+    assert record.hazardous_substance == "Yes"
+    assert record.dangerous_good == "No"
+    assert record.dangerous_goods_class == "3"
+
+
+def test_extract_fields_from_pdf():
+    pdf_path = FIXTURE_DIR / "sample.pdf"
+    with open(pdf_path, "rb") as f:
+        data = f.read()
+    text = extract_text_from_pdf(data)
+    record = extract_fields(text)
+    assert record.product_name == "Fancy Stuff"
+    assert record.vendor == "ExampleCorp"
+    assert record.issue_date == "12/04/2024"
+


### PR DESCRIPTION
## Summary
- add sample fixtures and tests for the parser
- document how to run pytest

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf24b42d0832f9ed8f93a0153968c