### PR TITLE
Load patterns from YAML config

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,36 @@
+import os
+import re
+from typing import Dict, List, Pattern, Any
+
+import yaml
+
+
+def _compile_pattern(entry: Any) -> re.Pattern:
+    if isinstance(entry, dict):
+        pattern = entry.get("regex") or entry.get("pattern")
+        flags_str = entry.get("flags", "I")
+    else:
+        pattern = str(entry)
+        flags_str = "I"
+    flags = 0
+    for part in str(flags_str).split("|"):
+        part = part.strip()
+        if not part:
+            continue
+        flags |= getattr(re, part, 0)
+    return re.compile(pattern, flags)
+
+
+def load_patterns(path: str | None = None) -> Dict[str, List[Pattern]]:
+    if path is None:
+        path = os.path.join(os.path.dirname(__file__), "patterns.yml")
+    with open(path, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    compiled: Dict[str, List[Pattern]] = {}
+    for key, items in raw.items():
+        compiled[key] = [_compile_pattern(item) for item in (items or [])]
+    return compiled
+
+
+PATTERNS = load_patterns()
+

--- a/patterns.yml
+++ b/patterns.yml
@@ -1,0 +1,43 @@
+product_name:
+  - regex: "Product Identifier\\s*[:\\-]?\\s*(.+)"
+    flags: "I"
+  - regex: "^\\s*Product Name\\s*[:\\-]?\\s*(.+)$"
+    flags: "I|M"
+  - regex: "^\\s*Trade Name\\s*[:\\-]?\\s*(.+)$"
+    flags: "I|M"
+vendor:
+  - regex: "Manufacturer(?:/Supplier)?\\s*[:\\-]?\\s*(.+)"
+    flags: "I"
+  - regex: "Company Name\\s*[:\\-]?\\s*(.+)"
+    flags: "I"
+  - regex: "Supplier\\s*[:\\-]?\\s*(.+)"
+    flags: "I"
+issue_date:
+  - regex: "(Revision|Issue|Date of issue|Version date)\\s*[:\\-]?\\s*(\\d{1,2}[/-]\\d{1,2}[/-]\\d{2,4})"
+    flags: "I"
+  - regex: "(Prepared|Last revised)\\s*[:\\-]?\\s*(\\d{1,2}[/-]\\d{1,2}[/-]\\d{2,4})"
+    flags: "I"
+dangerous_goods_class:
+  - regex: "\\b(?:Dangerous\\s+Goods\\s*)?Class(?:/Division)?\\s*[:\\-]?\\s*([0-9A-Za-z\\.]+)\\b"
+    flags: "I"
+un_number:
+  - regex: "\\bUN\\s*(\\d{3,4})\\b"
+    flags: "I"
+packing_group:
+  - regex: "Packing\\s+Group\\s*[:\\-]?\\s*(I{1,3}|II|III)\\b"
+    flags: "I"
+subsidiary_risks:
+  - regex: "Subsidiary Risk[s]?\\s*[:\\-]?\\s*(.+)"
+    flags: "I"
+cas_number:
+  - regex: "\\bCAS(?: No\\.| Number)?\\s*[:\\-]?\\s*([0-9]{2,7}-[0-9]{2}-[0-9])"
+    flags: "I"
+hazardous_substance:
+  - regex: "Hazardous Substance\\s*[:\\-]?\\s*(Yes|No)\\b"
+    flags: "I"
+dangerous_good:
+  - regex: "Dangerous Goods?\\s*[:\\-]?\\s*(Yes|No)\\b"
+    flags: "I"
+description_section2:
+  - regex: "Section\\s*2[^\\n]*\\n(.{0,800})"
+    flags: "I|S"

--- a/readme.md
+++ b/readme.md
@@ -144,12 +144,26 @@ Outputs:
 
 ## 🛠 Customizing Patterns
 
-Edit the `PATTERNS` dict in `sds_parser.py`. For each new supplier:
+Regex patterns are now loaded from `patterns.yml` at startup. To add or tweak
+patterns, edit that file instead of the code.
 
-- Parse once.
-- If field missing, inspect raw extracted text (add temporary `print(text[:2000])` or log to file).
-- Craft a new regex capturing just the desired portion.
-- Order matters: **most specific first**.
+Each entry maps a field name to one or more regex objects. A pattern entry can be
+just a string (defaults to the `IGNORECASE` flag) or a dictionary with `regex`
+and `flags` values. Flags are the standard Python `re` constants joined by `|`
+(e.g. `"I|M"` for `re.IGNORECASE | re.MULTILINE`).
+
+Example snippet:
+
+```yaml
+product_name:
+  - regex: "^\s*Product Name\s*[:\-]?\s*(.+)$"
+    flags: "I|M"
+  - regex: "^\s*Trade Name\s*[:\-]?\s*(.+)$"
+    flags: "I|M"
+```
+
+Parse once and, if a field is missing, inspect the raw text to craft a new
+regex. Order matters: **most specific first**.
 
 **Tip:** Keep a small test corpus; add a basic unit test per new pattern to avoid regressions.
 
@@ -182,7 +196,7 @@ Fixtures with example SDS snippets live in `tests/fixtures`.
 
 ## 🧰 Optional Enhancements
 
-- **Pattern Config File:** `patterns.yml` loaded on startup.
+- **Pattern Config File:** `patterns.yml` loaded on startup (implemented).
 - **Confidence Scoring:** Count pattern hits / fallback usage.
 - **Duplicate Detection:** Add PDF hash & timestamp columns.
 - **Dockerization:** Lightweight container for deployment.

--- a/sds_parser.py
+++ b/sds_parser.py
@@ -90,47 +90,8 @@ _output_dir = os.path.dirname(os.path.abspath(OUTPUT_CSV))
 if _output_dir:
     os.makedirs(_output_dir, exist_ok=True)
 
-# Regex pattern definitions; each field may have multiple alternatives.
-PATTERNS: Dict[str, List[re.Pattern]] = {
-    "product_name": [
-        re.compile(r"Product Identifier\s*[:\-]?\s*(.+)", re.I),
-        re.compile(r"^\s*Product Name\s*[:\-]?\s*(.+)$", re.I | re.M),
-        re.compile(r"^\s*Trade Name\s*[:\-]?\s*(.+)$", re.I | re.M),
-    ],
-    "vendor": [
-        re.compile(r"Manufacturer(?:/Supplier)?\s*[:\-]?\s*(.+)", re.I),
-        re.compile(r"Company Name\s*[:\-]?\s*(.+)", re.I),
-        re.compile(r"Supplier\s*[:\-]?\s*(.+)", re.I),
-    ],
-    "issue_date": [
-        re.compile(r"(Revision|Issue|Date of issue|Version date)\s*[:\-]?\s*(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})", re.I),
-        re.compile(r"(Prepared|Last revised)\s*[:\-]?\s*(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})", re.I),
-    ],
-    "dangerous_goods_class": [
-        re.compile(r"\b(?:Dangerous\s+Goods\s*)?Class(?:/Division)?\s*[:\-]?\s*([0-9A-Za-z\.]+)\b", re.I),
-    ],
-    "un_number": [
-        re.compile(r"\bUN\s*(\d{3,4})\b", re.I),
-    ],
-    "packing_group": [
-        re.compile(r"Packing\s+Group\s*[:\-]?\s*(I{1,3}|II|III)\b", re.I),
-    ],
-    "subsidiary_risks": [
-        re.compile(r"Subsidiary Risk[s]?\s*[:\-]?\s*(.+)", re.I),
-    ],
-    "cas_number": [
-        re.compile(r"\bCAS(?: No\.| Number)?\s*[:\-]?\s*([0-9]{2,7}-[0-9]{2}-[0-9])", re.I),
-    ],
-    "hazardous_substance": [
-        re.compile(r"Hazardous Substance\s*[:\-]?\s*(Yes|No)\b", re.I),
-    ],
-    "dangerous_good": [
-        re.compile(r"Dangerous Goods?\s*[:\-]?\s*(Yes|No)\b", re.I),
-    ],
-    "description_section2": [
-        re.compile(r"Section\s*2[^\n]*\n(.{0,800})", re.I | re.S),
-    ],
-}
+# Regex pattern definitions are loaded from patterns.yml via config.py
+from config import PATTERNS
 
 DATE_FORMATS_IN = ["%d/%m/%Y", "%d-%m-%Y", "%d/%m/%y", "%Y-%m-%d", "%m/%d/%Y"]
 


### PR DESCRIPTION
## Summary
- add `config.py` to parse YAML patterns
- store regexes in new `patterns.yml`
- import patterns from config in `sds_parser.py`
- document YAML format in README with example

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687cf54b9888832f9cb48bb5e5d61346